### PR TITLE
修正质数集合符号P

### DIFF
--- a/ethereum_yellow_paper_cn.tex
+++ b/ethereum_yellow_paper_cn.tex
@@ -2445,7 +2445,7 @@ The size of the cache, $c_{size}$, is calculated using
 \end{equation}
 \begin{equation}
  E_{\mathrm{prime}}(x, y) = \begin{cases}
-x & \text{if} \quad x / y \in \mathbb{N} \\
+x & \text{if} \quad x / y \in \mathbb{P} \\
 E_{\mathrm{prime}}(x - 2 \cdot y, y) & \text{otherwise}
 \end{cases}
 \end{equation}


### PR DESCRIPTION
历史原因解释：英文原版paper在一次修复自然数集合符号N的过程中，把所有的符号“P”改为了符号“N”，详见https://github.com/ethereum/yellowpaper/commit/66d3a3d17d938ac2730342cf1e60cf34d0fc6f51#diff-9f702e1491c55da9d76a68d651278764

虽然大部分的改动是对的，但是这一处本来就应该是质数集合符号P。我已经在ethereum/yellowpaper项目中提交了更新（尚未合并），现同步到中文版。