### PR TITLE
添加缺失参数和符号

### DIFF
--- a/ethereum_yellow_paper_cn.tex
+++ b/ethereum_yellow_paper_cn.tex
@@ -2561,11 +2561,11 @@ In order to add random dataset nodes to the mix, the $E_{\mathrm{accesses}}$ fun
 \begin{equation}
  E_{\mathrm{accesses}}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i) = \begin{cases}
 E_{mixdataset}(\mathbf{d}, \mathbf{m},  \mathbf{s}, i) & \text{if} \quad i = J_{\mathrm{accesses}} -2 \\
-E_{\mathrm{accesses}}(E_{mixdataset}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i), \mathbf{s}, i + 1) & \text{otherwise}
+E_{\mathrm{accesses}}(\mathbf{d}, E_{mixdataset}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i), \mathbf{s}, i + 1) & \text{otherwise}
 \end{cases}
 \end{equation}
 \begin{equation}
- E_{mixdataset}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i) = E_\text{\tiny FNV}(\mathbf{m}, E_{newdata}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i)
+ E_{mixdataset}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i) = E_\text{\tiny FNV}(\mathbf{m}, E_{newdata}(\mathbf{d}, \mathbf{m}, \mathbf{s}, i))
 \end{equation}
 $E_{newdata}$ returns an array with $n_{mix}$ elements:
 \begin{equation}


### PR DESCRIPTION
Eaccesses函数的otherwise分支，缺失第一个参数d。
Emixdataset函数，缺少右侧括号。
本次修改范围：
![image](https://user-images.githubusercontent.com/4555304/62181492-060cc300-b386-11e9-8d48-e90cbd1e2195.png)

修改后：
![image](https://user-images.githubusercontent.com/4555304/62181458-f3928980-b385-11e9-89a1-fa24bcc4d0d3.png)
